### PR TITLE
Add UIPlugin — embedded web UI for Fetcharr

### DIFF
--- a/UIPlugin/pom.xml
+++ b/UIPlugin/pom.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>me.egg82</groupId>
+        <artifactId>fetcharr-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>fetcharr-ui</artifactId>
+    <version>${ui.version}</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/*.properties</include>
+                    <include>**/*.yaml</include>
+                    <include>**/*.yml</include>
+                </includes>
+            </resource>
+
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>**/*.html</include>
+                    <include>**/*.css</include>
+                    <include>**/*.js</include>
+                </includes>
+            </resource>
+        </resources>
+
+        <sourceDirectory>src/main/java</sourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.21.0</version>
+                <configuration>
+                    <rulesUri>file:///${project.basedir}/../versions.xml</rulesUri>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>LICENSE-2.0.txt</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>egg82-repo-releases</id>
+            <url>https://repo.egg82.me/releases/</url>
+        </repository>
+        <repository>
+            <id>egg82-repo-snapshots</id>
+            <url>https://repo.egg82.me/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>me.egg82</groupId>
+            <artifactId>fetcharr-api</artifactId>
+            <version>${api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.egg82</groupId>
+            <artifactId>arr-lib</artifactId>
+            <version>${lib.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${jetbrains.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sasorio</groupId>
+            <artifactId>event-api</artifactId>
+            <version>${event.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.spongepowered</groupId>
+            <artifactId>configurate-core</artifactId>
+            <version>${configurate.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spongepowered</groupId>
+            <artifactId>configurate-yaml</artifactId>
+            <version>${configurate.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/UIPlugin/src/main/java/me/egg82/fuiplugin/EventEntry.java
+++ b/UIPlugin/src/main/java/me/egg82/fuiplugin/EventEntry.java
@@ -1,0 +1,170 @@
+package me.egg82.fuiplugin;
+
+import me.egg82.arr.lidarr.v1.schema.ArtistResource;
+import me.egg82.arr.radarr.v3.schema.MovieResource;
+import me.egg82.arr.sonarr.v3.schema.SeriesResource;
+import me.egg82.fetcharr.api.event.FetcharrEvent;
+import me.egg82.fetcharr.api.event.update.AbstractUpdaterEvent;
+import me.egg82.fetcharr.api.event.update.lidarr.*;
+import me.egg82.fetcharr.api.event.update.radarr.*;
+import me.egg82.fetcharr.api.event.update.sonarr.*;
+import me.egg82.fetcharr.api.event.update.whisparr.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Instant;
+
+public record EventEntry(
+        @NotNull Instant time,
+        @NotNull String type,
+        @NotNull String service,
+        @NotNull String updaterUrl,
+        @NotNull String title,
+        boolean cancelled
+) {
+    public static @NotNull EventEntry from(@NotNull FetcharrEvent event) {
+        Instant time = Instant.now();
+        String updaterUrl = "";
+
+        if (event instanceof AbstractUpdaterEvent ae) {
+            try {
+                updaterUrl = ae.updater().config().url();
+            } catch (Exception ignored) { }
+        }
+
+        // Radarr
+        if (event instanceof RadarrUpdateMovieEvent e) {
+            return new EventEntry(time, "RadarrUpdateMovie", "radarr", updaterUrl, radarrTitle(e.resource()), false);
+        }
+        if (event instanceof RadarrSelectMovieEvent e) {
+            return new EventEntry(time, "RadarrSelectMovie", "radarr", updaterUrl, radarrTitle(e.resource()), false);
+        }
+        if (event instanceof RadarrSkipMovieSelectionEvent e) {
+            return new EventEntry(time, "RadarrSkipMovie", "radarr", updaterUrl,
+                    radarrTitle(e.resource()) + " [" + e.reason().name() + "]", true);
+        }
+        if (event instanceof RadarrFetchMovieEvent) {
+            return new EventEntry(time, "RadarrFetchMovie", "radarr", updaterUrl, "fetched from API", false);
+        }
+        if (event instanceof RadarrSearchEvent e) {
+            int count = e.resources().size();
+            return new EventEntry(time, "RadarrSearch", "radarr", updaterUrl, count + " movie" + (count != 1 ? "s" : ""), false);
+        }
+
+        // Sonarr
+        if (event instanceof SonarrUpdateSeriesEvent e) {
+            return new EventEntry(time, "SonarrUpdateSeries", "sonarr", updaterUrl, sonarrTitle(e.resource()), false);
+        }
+        if (event instanceof SonarrSelectSeriesEvent e) {
+            return new EventEntry(time, "SonarrSelectSeries", "sonarr", updaterUrl, sonarrTitle(e.resource()), false);
+        }
+        if (event instanceof SonarrSkipSeriesSelectionEvent e) {
+            return new EventEntry(time, "SonarrSkipSeries", "sonarr", updaterUrl,
+                    sonarrTitle(e.resource()) + " [" + e.reason().name() + "]", true);
+        }
+        if (event instanceof SonarrFetchEpisodesEvent e) {
+            return new EventEntry(time, "SonarrFetchEpisodes", "sonarr", updaterUrl, sonarrTitle(e.series()), false);
+        }
+        if (event instanceof SonarrFetchSeriesEvent) {
+            return new EventEntry(time, "SonarrFetchSeries", "sonarr", updaterUrl, "fetched from API", false);
+        }
+        if (event instanceof SonarrSearchEvent e) {
+            int count = e.resources().size();
+            return new EventEntry(time, "SonarrSearch", "sonarr", updaterUrl, count + " series", false);
+        }
+
+        // Lidarr
+        if (event instanceof LidarrUpdateArtistEvent e) {
+            return new EventEntry(time, "LidarrUpdateArtist", "lidarr", updaterUrl, lidarrTitle(e.resource()), false);
+        }
+        if (event instanceof LidarrSelectArtistEvent e) {
+            return new EventEntry(time, "LidarrSelectArtist", "lidarr", updaterUrl, lidarrTitle(e.resource()), false);
+        }
+        if (event instanceof LidarrSkipArtistSelectionEvent e) {
+            return new EventEntry(time, "LidarrSkipArtist", "lidarr", updaterUrl,
+                    lidarrTitle(e.resource()) + " [" + e.reason().name() + "]", true);
+        }
+        if (event instanceof LidarrFetchAlbumsEvent e) {
+            return new EventEntry(time, "LidarrFetchAlbums", "lidarr", updaterUrl, lidarrTitle(e.artist()), false);
+        }
+        if (event instanceof LidarrFetchTracksEvent e) {
+            return new EventEntry(time, "LidarrFetchTracks", "lidarr", updaterUrl, lidarrTitle(e.artist()), false);
+        }
+        if (event instanceof LidarrFetchArtistEvent) {
+            return new EventEntry(time, "LidarrFetchArtist", "lidarr", updaterUrl, "fetched from API", false);
+        }
+        if (event instanceof LidarrSearchEvent e) {
+            int count = e.resources().size();
+            return new EventEntry(time, "LidarrSearch", "lidarr", updaterUrl, count + " artist" + (count != 1 ? "s" : ""), false);
+        }
+
+        // Whisparr
+        if (event instanceof WhisparrUpdateMovieEvent e) {
+            return new EventEntry(time, "WhisparrUpdateMovie", "whisparr", updaterUrl, whisparrTitle(e.resource()), false);
+        }
+        if (event instanceof WhisparrSelectMovieEvent e) {
+            return new EventEntry(time, "WhisparrSelectMovie", "whisparr", updaterUrl, whisparrTitle(e.resource()), false);
+        }
+        if (event instanceof WhisparrSkipMovieSelectionEvent e) {
+            return new EventEntry(time, "WhisparrSkipMovie", "whisparr", updaterUrl,
+                    whisparrTitle(e.resource()) + " [" + e.reason().name() + "]", true);
+        }
+        if (event instanceof WhisparrFetchMovieEvent) {
+            return new EventEntry(time, "WhisparrFetchMovie", "whisparr", updaterUrl, "fetched from API", false);
+        }
+        if (event instanceof WhisparrSearchEvent e) {
+            int count = e.resources().size();
+            return new EventEntry(time, "WhisparrSearch", "whisparr", updaterUrl, count + " movie" + (count != 1 ? "s" : ""), false);
+        }
+
+        return new EventEntry(time, event.eventType().getSimpleName(), "unknown", updaterUrl, "", false);
+    }
+
+    private static @NotNull String radarrTitle(@Nullable MovieResource r) {
+        if (r == null) return "Unknown";
+        String title = r.getTitle();
+        if (title == null || title.isBlank()) return "Unknown";
+        Integer year = r.getYear();
+        return (year != null && year > 0) ? title + " (" + year + ")" : title;
+    }
+
+    private static @NotNull String sonarrTitle(@Nullable SeriesResource r) {
+        if (r == null) return "Unknown";
+        String title = r.getTitle();
+        return (title != null && !title.isBlank()) ? title : "Unknown";
+    }
+
+    private static @NotNull String lidarrTitle(@Nullable ArtistResource r) {
+        if (r == null) return "Unknown";
+        String name = r.getArtistName();
+        return (name != null && !name.isBlank()) ? name : "Unknown";
+    }
+
+    private static @NotNull String whisparrTitle(@Nullable me.egg82.arr.whisparr.v3.schema.MovieResource r) {
+        if (r == null) return "Unknown";
+        String title = r.getTitle();
+        if (title == null || title.isBlank()) return "Unknown";
+        Integer year = r.getYear();
+        return (year != null && year > 0) ? title + " (" + year + ")" : title;
+    }
+
+    /** Serialize to a JSON object string (no external library needed). */
+    public @NotNull String toJson() {
+        return "{" +
+                "\"time\":\"" + jsonEscape(time.toString()) + "\"," +
+                "\"type\":\"" + jsonEscape(type) + "\"," +
+                "\"service\":\"" + jsonEscape(service) + "\"," +
+                "\"updaterUrl\":\"" + jsonEscape(updaterUrl) + "\"," +
+                "\"title\":\"" + jsonEscape(title) + "\"," +
+                "\"cancelled\":" + cancelled +
+                "}";
+    }
+
+    private static @NotNull String jsonEscape(@NotNull String s) {
+        return s.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+}

--- a/UIPlugin/src/main/java/me/egg82/fuiplugin/EventLog.java
+++ b/UIPlugin/src/main/java/me/egg82/fuiplugin/EventLog.java
@@ -1,0 +1,40 @@
+package me.egg82.fuiplugin;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+public class EventLog {
+    private final int maxSize;
+    private final Deque<EventEntry> entries;
+
+    public EventLog(int maxSize) {
+        this.maxSize = maxSize;
+        this.entries = new ArrayDeque<>(maxSize);
+    }
+
+    public synchronized void add(@NotNull EventEntry entry) {
+        if (entries.size() >= maxSize) {
+            entries.pollFirst();
+        }
+        entries.addLast(entry);
+    }
+
+    public synchronized @NotNull List<EventEntry> snapshot() {
+        return new ArrayList<>(entries);
+    }
+
+    public @NotNull String toJson() {
+        List<EventEntry> snapshot = snapshot();
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < snapshot.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append(snapshot.get(i).toJson());
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/UIPlugin/src/main/java/me/egg82/fuiplugin/UIPlugin.java
+++ b/UIPlugin/src/main/java/me/egg82/fuiplugin/UIPlugin.java
@@ -1,0 +1,117 @@
+package me.egg82.fuiplugin;
+
+import com.sasorio.event.EventConfig;
+import me.egg82.fetcharr.api.FetcharrAPIProvider;
+import me.egg82.fetcharr.api.event.FetcharrEvent;
+import me.egg82.fetcharr.api.plugin.Plugin;
+import me.egg82.fetcharr.api.plugin.PluginContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spongepowered.configurate.CommentedConfigurationNode;
+import org.spongepowered.configurate.yaml.YamlConfigurationLoader;
+
+import java.io.*;
+
+public class UIPlugin implements Plugin {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private volatile boolean started = false;
+    private UIServer server;
+    private EventLog eventLog;
+
+    public UIPlugin() {
+        logger.info("UI plugin ready to init");
+    }
+
+    @Override
+    public void init(@NotNull PluginContext context) throws Exception {
+        CommentedConfigurationNode config = loadConfig(new File(context.configDir(), "config.yaml"));
+        int port = config != null ? config.node("port").getInt(8080) : 8080;
+        int maxEvents = config != null ? config.node("max-events").getInt(500) : 500;
+
+        eventLog = new EventLog(maxEvents);
+        server = new UIServer(port, eventLog);
+
+        FetcharrAPIProvider.instance().events().subscribe(
+                FetcharrEvent.class,
+                EventConfig.of(Integer.MAX_VALUE, false, false),
+                this::onEvent
+        );
+
+        logger.info("UI plugin initialized, will serve on port {}", port);
+    }
+
+    @Override
+    public void start() throws Exception {
+        server.start();
+        started = true;
+        logger.info("UI plugin started");
+    }
+
+    @Override
+    public void stop() throws Exception {
+        started = false;
+        if (server != null) {
+            server.stop();
+        }
+        logger.info("UI plugin stopped");
+    }
+
+    private void onEvent(@NotNull FetcharrEvent event) {
+        if (!started) return;
+        eventLog.add(EventEntry.from(event));
+        server.broadcast(eventLog.toJson());
+    }
+
+    private @Nullable CommentedConfigurationNode loadConfig(@NotNull File configFile) {
+        if (!configFile.exists() || !configFile.isFile() || configFile.length() == 0L) {
+            try (InputStream resource = getClass().getResourceAsStream("/config.yaml");
+                 FileWriter out = new FileWriter(configFile);
+                 BufferedWriter writer = new BufferedWriter(out)) {
+
+                if (resource == null) {
+                    logger.error("Could not get resource /config.yaml");
+                    return null;
+                }
+
+                File parent = configFile.getParentFile();
+                if (parent.exists() && !parent.isDirectory()) {
+                    if (!parent.delete()) {
+                        logger.error("Could not delete file {}", parent.getAbsolutePath());
+                        return null;
+                    }
+                }
+                if (!parent.exists() && !parent.mkdirs()) {
+                    logger.error("Could not create directory {}", parent.getAbsolutePath());
+                    return null;
+                }
+
+                byte[] buffer = new byte[250];
+                int len;
+                while ((len = resource.read(buffer)) > 0) {
+                    char[] chars = new char[len];
+                    for (int i = 0; i < len; i++) {
+                        chars[i] = (char) buffer[i];
+                    }
+                    writer.write(chars);
+                }
+            } catch (IOException ex) {
+                logger.error("Could not write default config to {}", configFile.getAbsolutePath(), ex);
+                return null;
+            }
+        }
+
+        try (FileReader file = new FileReader(configFile);
+             BufferedReader reader = new BufferedReader(file)) {
+            return YamlConfigurationLoader.builder()
+                    .source(() -> reader)
+                    .build()
+                    .load();
+        } catch (IOException ex) {
+            logger.error("Could not read config file at {}", configFile.getAbsolutePath(), ex);
+            return null;
+        }
+    }
+}

--- a/UIPlugin/src/main/java/me/egg82/fuiplugin/UIServer.java
+++ b/UIPlugin/src/main/java/me/egg82/fuiplugin/UIServer.java
@@ -1,0 +1,261 @@
+package me.egg82.fuiplugin;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import me.egg82.fetcharr.api.FetcharrAPIProvider;
+import me.egg82.fetcharr.api.model.plugin.EnabledPlugin;
+import me.egg82.fetcharr.api.model.update.Updater;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.*;
+
+public class UIServer {
+    private static final Logger logger = LoggerFactory.getLogger(UIServer.class);
+
+    private final int port;
+    private final EventLog eventLog;
+    private final Set<BlockingQueue<String>> sseClients = ConcurrentHashMap.newKeySet();
+
+    private HttpServer httpServer;
+
+    public UIServer(int port, @NotNull EventLog eventLog) {
+        this.port = port;
+        this.eventLog = eventLog;
+    }
+
+    public void start() throws IOException {
+        httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+        httpServer.setExecutor(Executors.newCachedThreadPool());
+
+        httpServer.createContext("/api/status", this::handleStatus);
+        httpServer.createContext("/api/events", this::handleEvents);
+        httpServer.createContext("/api/stream", this::handleStream);
+        httpServer.createContext("/", this::handleStatic);
+
+        httpServer.start();
+        logger.info("Fetcharr UI available at http://localhost:{}/", port);
+    }
+
+    public void stop() {
+        if (httpServer != null) {
+            // Unblock all SSE clients
+            for (BlockingQueue<String> queue : sseClients) {
+                queue.offer("__CLOSE__");
+            }
+            httpServer.stop(1);
+        }
+    }
+
+    /** Push a JSON payload to all connected SSE clients. */
+    public void broadcast(@NotNull String eventsJson) {
+        String message = "event: events\ndata: " + eventsJson + "\n\n";
+        for (BlockingQueue<String> queue : sseClients) {
+            queue.offer(message);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Handlers
+    // -------------------------------------------------------------------------
+
+    private void handleStatus(@NotNull HttpExchange exchange) throws IOException {
+        if (!exchange.getRequestMethod().equalsIgnoreCase("GET")) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+        addCorsHeaders(exchange);
+        String json = buildStatusJson();
+        sendJson(exchange, 200, json);
+    }
+
+    private void handleEvents(@NotNull HttpExchange exchange) throws IOException {
+        if (!exchange.getRequestMethod().equalsIgnoreCase("GET")) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+        addCorsHeaders(exchange);
+        sendJson(exchange, 200, eventLog.toJson());
+    }
+
+    private void handleStream(@NotNull HttpExchange exchange) throws IOException {
+        if (!exchange.getRequestMethod().equalsIgnoreCase("GET")) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+        exchange.getResponseHeaders().set("Content-Type", "text/event-stream; charset=utf-8");
+        exchange.getResponseHeaders().set("Cache-Control", "no-cache");
+        exchange.getResponseHeaders().set("Connection", "keep-alive");
+        exchange.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
+        exchange.sendResponseHeaders(200, 0);
+
+        BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+        sseClients.add(queue);
+
+        try (OutputStream out = exchange.getResponseBody()) {
+            // Send initial data immediately
+            String initial = "event: events\ndata: " + eventLog.toJson() + "\n\n";
+            out.write(initial.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+
+            while (true) {
+                String message;
+                try {
+                    message = queue.poll(25, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+
+                if (message == null) {
+                    // Send a heartbeat comment to keep the connection alive
+                    out.write(": heartbeat\n\n".getBytes(StandardCharsets.UTF_8));
+                } else if (message.equals("__CLOSE__")) {
+                    break;
+                } else {
+                    out.write(message.getBytes(StandardCharsets.UTF_8));
+                }
+                out.flush();
+            }
+        } catch (IOException ignored) {
+            // Client disconnected
+        } finally {
+            sseClients.remove(queue);
+        }
+    }
+
+    private void handleStatic(@NotNull HttpExchange exchange) throws IOException {
+        if (!exchange.getRequestMethod().equalsIgnoreCase("GET")) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+
+        String path = exchange.getRequestURI().getPath();
+        if (path.equals("/") || path.isEmpty()) {
+            path = "/web/index.html";
+        } else {
+            path = "/web" + path;
+        }
+
+        byte[] content = loadResource(path);
+        if (content == null) {
+            byte[] notFound = "404 Not Found".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(404, notFound.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(notFound);
+            }
+            return;
+        }
+
+        String contentType = guessContentType(path);
+        exchange.getResponseHeaders().set("Content-Type", contentType);
+        exchange.sendResponseHeaders(200, content.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(content);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private @Nullable byte[] loadResource(@NotNull String path) {
+        try (InputStream is = getClass().getResourceAsStream(path)) {
+            if (is == null) return null;
+            return is.readAllBytes();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private @NotNull String guessContentType(@NotNull String path) {
+        if (path.endsWith(".html")) return "text/html; charset=utf-8";
+        if (path.endsWith(".css"))  return "text/css; charset=utf-8";
+        if (path.endsWith(".js"))   return "application/javascript; charset=utf-8";
+        return "application/octet-stream";
+    }
+
+    private void sendJson(@NotNull HttpExchange exchange, int status, @NotNull String json) throws IOException {
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    private void addCorsHeaders(@NotNull HttpExchange exchange) {
+        exchange.getResponseHeaders().set("Access-Control-Allow-Origin", "*");
+    }
+
+    private @NotNull String buildStatusJson() {
+        var api = FetcharrAPIProvider.instance();
+        boolean dryRun = api.updateManager().dryRun();
+
+        StringBuilder sb = new StringBuilder("{");
+        sb.append("\"dryRun\":").append(dryRun).append(",");
+
+        // Updaters
+        sb.append("\"updaters\":[");
+        var updaters = api.updateManager().updaters();
+        for (int i = 0; i < updaters.size(); i++) {
+            if (i > 0) sb.append(",");
+            appendUpdaterJson(sb, updaters.get(i));
+        }
+        sb.append("],");
+
+        // Plugins
+        sb.append("\"plugins\":[");
+        var plugins = api.pluginManager().plugins();
+        int pi = 0;
+        for (EnabledPlugin plugin : plugins) {
+            if (pi++ > 0) sb.append(",");
+            appendPluginJson(sb, plugin);
+        }
+        sb.append("]");
+
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private void appendUpdaterJson(@NotNull StringBuilder sb, @NotNull Updater u) {
+        var cfg = u.config();
+        sb.append("{");
+        sb.append("\"type\":\"").append(jsonEscape(cfg.type().name())).append("\",");
+        sb.append("\"url\":\"").append(jsonEscape(cfg.url())).append("\",");
+        sb.append("\"id\":").append(cfg.id()).append(",");
+        sb.append("\"searchAmount\":").append(cfg.searchAmount()).append(",");
+        sb.append("\"searchInterval\":\"").append(jsonEscape(cfg.searchInterval().toString())).append("\",");
+        sb.append("\"monitoredOnly\":").append(cfg.monitoredOnly()).append(",");
+        sb.append("\"missingStatus\":\"").append(jsonEscape(cfg.missingStatus().name())).append("\",");
+        sb.append("\"useCutoff\":").append(cfg.useCutoff());
+        sb.append("}");
+    }
+
+    private void appendPluginJson(@NotNull StringBuilder sb, @NotNull EnabledPlugin p) {
+        var desc = p.descriptor();
+        sb.append("{");
+        sb.append("\"id\":\"").append(jsonEscape(desc.id())).append("\",");
+        sb.append("\"name\":\"").append(jsonEscape(desc.name())).append("\",");
+        sb.append("\"version\":\"").append(jsonEscape(desc.version())).append("\",");
+        sb.append("\"description\":\"").append(jsonEscape(desc.description() != null ? desc.description() : "")).append("\"");
+        sb.append("}");
+    }
+
+    private static @NotNull String jsonEscape(@NotNull String s) {
+        return s.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+}

--- a/UIPlugin/src/main/resources/config.yaml
+++ b/UIPlugin/src/main/resources/config.yaml
@@ -1,0 +1,5 @@
+# Port the web UI will listen on
+port: 8080
+
+# Maximum number of events to keep in the activity log
+max-events: 500

--- a/UIPlugin/src/main/resources/plugin.yaml
+++ b/UIPlugin/src/main/resources/plugin.yaml
@@ -1,0 +1,6 @@
+id: ui
+name: UI
+version: ${ui.version}
+description: Web UI plugin for Fetcharr
+authors: [egg82]
+class: me.egg82.fuiplugin.UIPlugin

--- a/UIPlugin/src/main/resources/web/index.html
+++ b/UIPlugin/src/main/resources/web/index.html
@@ -1,0 +1,650 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fetcharr</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg:       #0f1117;
+    --surface:  #1a1d27;
+    --border:   #2a2d3d;
+    --accent:   #6c63ff;
+    --accent2:  #a78bfa;
+    --text:     #e2e8f0;
+    --muted:    #64748b;
+    --green:    #34d399;
+    --yellow:   #fbbf24;
+    --red:      #f87171;
+    --blue:     #60a5fa;
+    --purple:   #c084fc;
+    --orange:   #fb923c;
+    --radius:   8px;
+    --font:     'Segoe UI', system-ui, -apple-system, sans-serif;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font);
+    font-size: 14px;
+    line-height: 1.5;
+    min-height: 100vh;
+  }
+
+  /* ── Layout ── */
+  header {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 0 24px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    height: 56px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  .logo {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--accent2);
+    letter-spacing: -0.5px;
+  }
+
+  .status-badge {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--muted);
+  }
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--muted);
+    transition: background 0.3s;
+  }
+  .dot.live { background: var(--green); box-shadow: 0 0 6px var(--green); }
+  .dot.error { background: var(--red); }
+
+  .dry-run-badge {
+    background: #7c3aed33;
+    border: 1px solid var(--accent);
+    color: var(--accent2);
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    display: none;
+  }
+
+  main {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 24px;
+    display: grid;
+    grid-template-columns: 340px 1fr;
+    grid-template-rows: auto 1fr;
+    gap: 20px;
+  }
+
+  /* ── Cards ── */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+  }
+
+  .card-header {
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--border);
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .card-header .count {
+    background: var(--border);
+    color: var(--text);
+    padding: 1px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+
+  /* ── Updaters ── */
+  .updater-list { padding: 8px 0; }
+
+  .updater-item {
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .updater-item:last-child { border-bottom: none; }
+
+  .updater-top {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .service-pill {
+    font-size: 11px;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    flex-shrink: 0;
+  }
+  .pill-radarr   { background: #1e3a5f; color: #60a5fa; }
+  .pill-sonarr   { background: #1a3a2e; color: #34d399; }
+  .pill-lidarr   { background: #3b2a1a; color: #fb923c; }
+  .pill-whisparr { background: #3a1a2e; color: #f472b6; }
+  .pill-unknown  { background: #1e2130; color: var(--muted); }
+
+  .updater-url {
+    font-size: 13px;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .updater-meta {
+    display: flex;
+    gap: 12px;
+    font-size: 11px;
+    color: var(--muted);
+    flex-wrap: wrap;
+  }
+
+  .updater-meta span { white-space: nowrap; }
+
+  /* ── Plugins ── */
+  .plugin-list { padding: 8px 0; }
+
+  .plugin-item {
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .plugin-item:last-child { border-bottom: none; }
+
+  .plugin-name {
+    font-weight: 600;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .plugin-version {
+    font-size: 11px;
+    color: var(--muted);
+    background: var(--border);
+    padding: 1px 6px;
+    border-radius: 4px;
+  }
+
+  .plugin-desc { font-size: 12px; color: var(--muted); }
+
+  /* ── Activity Log ── */
+  .activity-card {
+    grid-column: 2;
+    grid-row: 1 / 3;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 100px);
+  }
+
+  .activity-controls {
+    padding: 10px 18px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .filter-btn {
+    padding: 4px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--muted);
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.15s;
+    font-family: var(--font);
+  }
+  .filter-btn:hover { border-color: var(--accent2); color: var(--accent2); }
+  .filter-btn.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+
+  .search-input {
+    margin-left: auto;
+    padding: 4px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text);
+    font-size: 12px;
+    font-family: var(--font);
+    width: 180px;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+  .search-input:focus { border-color: var(--accent2); }
+  .search-input::placeholder { color: var(--muted); }
+
+  .clear-btn {
+    padding: 4px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--muted);
+    font-size: 12px;
+    cursor: pointer;
+    font-family: var(--font);
+    transition: all 0.15s;
+  }
+  .clear-btn:hover { border-color: var(--red); color: var(--red); }
+
+  .log-container {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 0;
+    scroll-behavior: smooth;
+  }
+
+  .log-container::-webkit-scrollbar { width: 6px; }
+  .log-container::-webkit-scrollbar-track { background: transparent; }
+  .log-container::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+  .log-row {
+    display: grid;
+    grid-template-columns: 80px 140px 180px 1fr;
+    gap: 12px;
+    padding: 6px 18px;
+    border-bottom: 1px solid transparent;
+    align-items: center;
+    animation: fadeIn 0.2s ease;
+    transition: background 0.1s;
+  }
+  .log-row:hover { background: #ffffff08; }
+  .log-row.cancelled { opacity: 0.55; }
+
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-4px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  .log-time {
+    font-size: 11px;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .log-type {
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .log-updater {
+    font-size: 11px;
+    color: var(--muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .log-title {
+    font-size: 13px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .log-empty {
+    padding: 48px 18px;
+    text-align: center;
+    color: var(--muted);
+    font-size: 13px;
+  }
+
+  /* Service color coding */
+  .color-radarr   { color: var(--blue); }
+  .color-sonarr   { color: var(--green); }
+  .color-lidarr   { color: var(--orange); }
+  .color-whisparr { color: var(--purple); }
+  .color-unknown  { color: var(--muted); }
+  .color-cancelled { color: var(--red) !important; }
+
+  /* ── Responsive ── */
+  @media (max-width: 900px) {
+    main {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto auto auto;
+    }
+    .activity-card {
+      grid-column: 1;
+      grid-row: 3;
+      max-height: 600px;
+    }
+    .log-row {
+      grid-template-columns: 70px 120px 1fr;
+    }
+    .log-updater { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <span class="logo">fetcharr</span>
+  <span id="dry-run-badge" class="dry-run-badge">DRY RUN</span>
+  <div class="status-badge">
+    <div id="conn-dot" class="dot"></div>
+    <span id="conn-label">connecting…</span>
+  </div>
+</header>
+
+<main>
+  <!-- Updaters -->
+  <div class="card" id="updaters-card">
+    <div class="card-header">
+      Updaters
+      <span class="count" id="updater-count">0</span>
+    </div>
+    <div class="updater-list" id="updater-list">
+      <div class="log-empty">No updaters loaded</div>
+    </div>
+  </div>
+
+  <!-- Plugins -->
+  <div class="card" id="plugins-card">
+    <div class="card-header">
+      Plugins
+      <span class="count" id="plugin-count">0</span>
+    </div>
+    <div class="plugin-list" id="plugin-list">
+      <div class="log-empty">No plugins loaded</div>
+    </div>
+  </div>
+
+  <!-- Activity Log -->
+  <div class="card activity-card">
+    <div class="card-header">
+      Activity
+      <span class="count" id="event-count">0</span>
+    </div>
+    <div class="activity-controls">
+      <button class="filter-btn active" data-filter="all">All</button>
+      <button class="filter-btn" data-filter="radarr">Radarr</button>
+      <button class="filter-btn" data-filter="sonarr">Sonarr</button>
+      <button class="filter-btn" data-filter="lidarr">Lidarr</button>
+      <button class="filter-btn" data-filter="whisparr">Whisparr</button>
+      <input class="search-input" id="search-input" type="search" placeholder="Search…">
+      <button class="clear-btn" id="clear-btn">Clear</button>
+    </div>
+    <div class="log-container" id="log-container">
+      <div class="log-empty" id="log-empty">Waiting for events…</div>
+    </div>
+  </div>
+</main>
+
+<script>
+(function () {
+  'use strict';
+
+  // ── State ──────────────────────────────────────────────────────────────────
+  let allEvents = [];
+  let activeFilter = 'all';
+  let searchQuery = '';
+  let autoScroll = true;
+
+  // ── DOM refs ───────────────────────────────────────────────────────────────
+  const connDot    = document.getElementById('conn-dot');
+  const connLabel  = document.getElementById('conn-label');
+  const dryRunBadge = document.getElementById('dry-run-badge');
+  const updaterList = document.getElementById('updater-list');
+  const updaterCount = document.getElementById('updater-count');
+  const pluginList  = document.getElementById('plugin-list');
+  const pluginCount = document.getElementById('plugin-count');
+  const logContainer = document.getElementById('log-container');
+  const logEmpty    = document.getElementById('log-empty');
+  const eventCount  = document.getElementById('event-count');
+  const searchInput = document.getElementById('search-input');
+  const clearBtn    = document.getElementById('clear-btn');
+
+  // ── SSE connection ─────────────────────────────────────────────────────────
+  let evtSource = null;
+
+  function connect() {
+    if (evtSource) evtSource.close();
+    evtSource = new EventSource('/api/stream');
+
+    evtSource.addEventListener('events', function (e) {
+      try {
+        const events = JSON.parse(e.data);
+        allEvents = events;
+        renderLog();
+      } catch (err) {
+        console.error('Failed to parse SSE events', err);
+      }
+    });
+
+    evtSource.onopen = function () {
+      connDot.className = 'dot live';
+      connLabel.textContent = 'live';
+    };
+
+    evtSource.onerror = function () {
+      connDot.className = 'dot error';
+      connLabel.textContent = 'reconnecting…';
+      evtSource.close();
+      setTimeout(connect, 3000);
+    };
+  }
+
+  // ── Fetch status (updaters + plugins) ─────────────────────────────────────
+  function fetchStatus() {
+    fetch('/api/status')
+      .then(r => r.json())
+      .then(renderStatus)
+      .catch(err => console.error('Failed to fetch status', err));
+  }
+
+  function renderStatus(status) {
+    // Dry run
+    dryRunBadge.style.display = status.dryRun ? 'block' : 'none';
+
+    // Updaters
+    updaterCount.textContent = status.updaters.length;
+    if (status.updaters.length === 0) {
+      updaterList.innerHTML = '<div class="log-empty">No updaters loaded</div>';
+    } else {
+      updaterList.innerHTML = status.updaters.map(renderUpdater).join('');
+    }
+
+    // Plugins
+    pluginCount.textContent = status.plugins.length;
+    if (status.plugins.length === 0) {
+      pluginList.innerHTML = '<div class="log-empty">No plugins loaded</div>';
+    } else {
+      pluginList.innerHTML = status.plugins.map(renderPlugin).join('');
+    }
+  }
+
+  function renderUpdater(u) {
+    const service = (u.type || '').toLowerCase();
+    const pillClass = 'pill-' + (servicePillClass(service));
+    const urlDisplay = u.url.replace(/^https?:\/\//, '');
+    return `<div class="updater-item">
+      <div class="updater-top">
+        <span class="service-pill ${pillClass}">${esc(u.type)}</span>
+        <span class="updater-url" title="${esc(u.url)}">${esc(urlDisplay)}</span>
+      </div>
+      <div class="updater-meta">
+        <span>Search: ${esc(String(u.searchAmount))}</span>
+        <span>Interval: ${esc(u.searchInterval)}</span>
+        <span>Status: ${esc(u.missingStatus)}</span>
+        ${u.monitoredOnly ? '<span>Monitored only</span>' : ''}
+        ${u.useCutoff ? '<span>Use cutoff</span>' : ''}
+      </div>
+    </div>`;
+  }
+
+  function renderPlugin(p) {
+    return `<div class="plugin-item">
+      <div class="plugin-name">
+        ${esc(p.name)}
+        <span class="plugin-version">${esc(p.version)}</span>
+      </div>
+      ${p.description ? `<div class="plugin-desc">${esc(p.description)}</div>` : ''}
+    </div>`;
+  }
+
+  // ── Log rendering ──────────────────────────────────────────────────────────
+  function renderLog() {
+    const filtered = allEvents.filter(e => {
+      if (activeFilter !== 'all' && e.service !== activeFilter) return false;
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        if (!e.title.toLowerCase().includes(q) &&
+            !e.type.toLowerCase().includes(q) &&
+            !e.updaterUrl.toLowerCase().includes(q)) return false;
+      }
+      return true;
+    });
+
+    eventCount.textContent = filtered.length;
+
+    if (filtered.length === 0) {
+      logEmpty.style.display = 'block';
+      // Remove all rows but keep empty message
+      Array.from(logContainer.querySelectorAll('.log-row')).forEach(el => el.remove());
+      return;
+    }
+
+    logEmpty.style.display = 'none';
+
+    // Full re-render (events list is the source of truth)
+    const fragment = document.createDocumentFragment();
+    for (let i = filtered.length - 1; i >= 0; i--) {
+      fragment.appendChild(buildRow(filtered[i]));
+    }
+
+    // Replace children
+    while (logContainer.firstChild && logContainer.firstChild !== logEmpty) {
+      logContainer.removeChild(logContainer.firstChild);
+    }
+    logContainer.insertBefore(fragment, logContainer.firstChild);
+
+    if (autoScroll) {
+      logContainer.scrollTop = 0;
+    }
+  }
+
+  function buildRow(e) {
+    const div = document.createElement('div');
+    div.className = 'log-row' + (e.cancelled ? ' cancelled' : '');
+
+    const timeStr = formatTime(e.time);
+    const serviceClass = 'color-' + (e.service || 'unknown');
+    const typeClass = e.cancelled ? 'color-cancelled' : serviceClass;
+
+    div.innerHTML = `
+      <span class="log-time">${esc(timeStr)}</span>
+      <span class="log-type ${typeClass}">${esc(e.type)}</span>
+      <span class="log-updater" title="${esc(e.updaterUrl)}">${esc(shortUrl(e.updaterUrl))}</span>
+      <span class="log-title">${esc(e.title)}</span>
+    `;
+    return div;
+  }
+
+  function formatTime(isoStr) {
+    try {
+      const d = new Date(isoStr);
+      const h = String(d.getHours()).padStart(2, '0');
+      const m = String(d.getMinutes()).padStart(2, '0');
+      const s = String(d.getSeconds()).padStart(2, '0');
+      return `${h}:${m}:${s}`;
+    } catch { return isoStr; }
+  }
+
+  function shortUrl(url) {
+    if (!url) return '';
+    return url.replace(/^https?:\/\//, '').replace(/\/$/, '');
+  }
+
+  function servicePillClass(service) {
+    const known = ['radarr', 'sonarr', 'lidarr', 'whisparr'];
+    return known.includes(service) ? service : 'unknown';
+  }
+
+  function esc(str) {
+    if (str == null) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  // ── Controls ───────────────────────────────────────────────────────────────
+  document.querySelectorAll('.filter-btn').forEach(btn => {
+    btn.addEventListener('click', function () {
+      document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+      this.classList.add('active');
+      activeFilter = this.dataset.filter;
+      renderLog();
+    });
+  });
+
+  searchInput.addEventListener('input', function () {
+    searchQuery = this.value.trim();
+    renderLog();
+  });
+
+  clearBtn.addEventListener('click', function () {
+    allEvents = [];
+    renderLog();
+  });
+
+  // Pause auto-scroll when user scrolls up
+  logContainer.addEventListener('scroll', function () {
+    autoScroll = logContainer.scrollTop <= 10;
+  });
+
+  // ── Init ───────────────────────────────────────────────────────────────────
+  fetchStatus();
+  setInterval(fetchStatus, 15000);
+  connect();
+})();
+</script>
+</body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <api.version>2.1.0</api.version>
         <lib.version>1.0.2</lib.version>
         <webhook.version>1.1.0</webhook.version>
+        <ui.version>1.0.0</ui.version>
 
         <jetbrains.version>26.1.0</jetbrains.version>
 
@@ -179,5 +180,6 @@
         <module>API</module>
         <module>App</module>
         <module>Webhook</module>
+        <module>UIPlugin</module>
     </modules>
 </project>


### PR DESCRIPTION
Adds a new Maven module (UIPlugin) that serves a live web dashboard on port 8080 (configurable) using only the JDK's built-in HttpServer and pure HTML/CSS/JS with no external frontend dependencies.

How it works:
- Starts an embedded com.sun.net.httpserver.HttpServer on startup
- Subscribes to all FetcharrEvents and stores them in a capped circular buffer (default 500 entries)
- Serves a single-page dashboard at http://localhost:{port}/
- Pushes live updates to the browser via Server-Sent Events (/api/stream) with 25-second heartbeat keepalive to maintain the connection
- REST endpoints: /api/status (updaters + plugins JSON) and /api/events

UI features:
- Updaters panel — each *arr instance with type, URL, search amount, interval, missing status, monitored-only and cutoff flags
- Plugins panel — all loaded plugins with version and description
- Live activity log — newest-first, color-coded by service (Radarr=blue, Sonarr=green, Lidarr=orange, Whisparr=pink), with skipped/cancelled events visually dimmed
- Per-service filter buttons, full-text search, and clear log
- Dry Run badge in the header when fetcharr is in dry-run mode
- Status panel auto-refreshes every 15 seconds

This was vibecoded and used ~ 22,000 tokens
I hope it annoys reddit if you merge it 